### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,8 @@ services:
       - ./db:/var/lib/postgresql/data
     networks:
       - laravel_dotnet_network
+    ports:
+      - "5432:5432"
 
   dotnet_api-build:
     image: mcr.microsoft.com/dotnet/sdk:8.0


### PR DESCRIPTION
This pull request includes a small change to the `docker-compose.yml` file. The change exposes the PostgreSQL database service on port 5432 to allow external connections.

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R55-R56): Added port mapping for PostgreSQL service to expose port 5432.